### PR TITLE
adds !yaspstats powerrank feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -320,7 +320,7 @@ function yaspstats(bot, message) {
                     promiseList.push(getStats(steamUserMapping[userName], heroId));
                 });
                 Promise.all(promiseList).then(function(stats) {
-                    sortedStats = sortByKey(stats, 'powerRank');
+                    sortedStats = sortByKey(stats, 'powerRank').filter(function (stat) {return stat.totalGames > 0;});
                     var messagePieces = [];
                     for (var i = 0; i < sortedStats.length; i++) {
                         messagePieces.push(


### PR DESCRIPTION
new reverse map `steamUserReverseMapping` to look up user name from steam
id

new utility functions `sortByKey()` (sorts an array of objects according
to a specified key) and `promiseRequest()` (just a Promise wrapper for
`request`)

extracted yaspstats core logic into new async internal API function
`getStats(userId, heroId) -> object` where the object contains stats
related fields for that user-hero combination
 - this function gets called once for the usual `!yaspstats gilgi lich`
   commands and once per user for the new `!yaspstats powerrank lich`
   option